### PR TITLE
[Offline] - Don’t delete images when used in other trails

### DIFF
--- a/lib/bloc/trail/save_trail_bloc.dart
+++ b/lib/bloc/trail/save_trail_bloc.dart
@@ -96,7 +96,7 @@ class SaveTrailBloc extends Bloc<SaveTrailEvent, SaveTrailState> {
         trailsMap[trailId] = true;
         localImagesBox.put(image.url, trailsMap);
       } else {
-        print('already saved ${image.url}');
+        //print('already saved ${image.url}');
       }
     } else {
       trailsMap = {};
@@ -112,7 +112,7 @@ class SaveTrailBloc extends Bloc<SaveTrailEvent, SaveTrailState> {
     if (trailsMap != null && trailsMap[trailId] != null) {
       trailsMap.remove(trailId);
       if (trailsMap.isEmpty) {
-        print('delete image ${image.url}');
+        //print('delete image ${image.url}');
         await DefaultCacheManager().removeFile(image.url);
         return -1;
       }

--- a/lib/bloc/trail/save_trail_bloc.dart
+++ b/lib/bloc/trail/save_trail_bloc.dart
@@ -112,6 +112,7 @@ class SaveTrailBloc extends Bloc<SaveTrailEvent, SaveTrailState> {
     if (trailsMap != null && trailsMap[trailId] != null) {
       trailsMap.remove(trailId);
       if (trailsMap.isEmpty) {
+        print('delete image ${image.url}');
         await DefaultCacheManager().removeFile(image.url);
         return -1;
       }

--- a/lib/components/cards/download.dart
+++ b/lib/components/cards/download.dart
@@ -33,7 +33,7 @@ class DownloadCard extends StatefulWidget {
 
 class _DownloadCardState extends State<DownloadCard> {
   late bool isSelected;
-  late Box<dynamic> savedTrailsBox;
+  late Box<bool> savedTrailsBox;
 
   @override
   void initState() {

--- a/lib/components/map/map_ui.dart
+++ b/lib/components/map/map_ui.dart
@@ -28,7 +28,7 @@ class MapUI extends StatefulWidget {
 class _MapUIState extends State<MapUI> {
   GlobalKey trailPreviewUIKey = GlobalKey();
   double trailPreviewUIHeight = 0;
-  late Box<dynamic> savedTrailsBox;
+  late Box<bool> savedTrailsBox;
   bool isPreviewLocallySaved = false;
 
   @override

--- a/lib/components/panel/trails_panel.dart
+++ b/lib/components/panel/trails_panel.dart
@@ -22,7 +22,7 @@ class _TrailsPanelWidgetState extends State<TrailsPanelWidget> {
   bool isPanelOpened = false;
   bool isPanelMoving = false;
   MapMode _mapMode = MapMode.overview;
-  late Box<dynamic> savedTrailsBox;
+  late Box<bool> savedTrailsBox;
 
   @override
   void initState() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,11 +55,13 @@ void main() async {
   Hive.registerAdapter(t.SectionAPIAdapter());
   Hive.registerAdapter(ConnectivityResultAdapter());
 
-  await Hive.openBox('savedTrails');
   Box<Trails> trailsBox = await Hive.openBox('trails');
   Box<TrailDetails> trailBox = await Hive.openBox('trail');
   Box<t.Taxon> taxonBox = await Hive.openBox('taxon');
 
+  Box<Map<int, bool>> localImagesBox = await Hive.openBox('localImages');
+
+  Box<bool> saveTrailBox = await Hive.openBox('savedTrails');
   await Hive.openBox('appConfig');
 
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
@@ -95,7 +97,8 @@ void main() async {
           create: (context) => TrailBloc(
               trailRepo, BlocProvider.of<MapBloc>(context), trailBox)),
       BlocProvider<SaveTrailBloc>(
-          create: (context) => SaveTrailBloc(trailRepo, trailBox, taxonBox)),
+          create: (context) => SaveTrailBloc(
+              trailRepo, trailBox, taxonBox, saveTrailBox, localImagesBox)),
       BlocProvider<TrailsBloc>(
           create: (context) => TrailsBloc(trailsRepo, trailsBox)),
       BlocProvider<WalkBloc>(create: (context) => WalkBloc(walkRepo)),


### PR DESCRIPTION
Adding logic, to check if cached image is used in other trails before delete it.
If it does, image is kept in memory.

Closes #123 