### PR TITLE
[FIX] - Android 3-button navigation overlap with bottom UI elements

### DIFF
--- a/lib/components/map/map_ui.dart
+++ b/lib/components/map/map_ui.dart
@@ -135,7 +135,9 @@ class _MapUIState extends State<MapUI> {
               bottom: (widget.mapMode == MapMode.overview)
                   ? 120 + widget.bottomPadding
                   : (widget.mapMode == MapMode.preview)
-                      ? 145 + LayoutUtils.getSizes(trailPreviewUIKey).height
+                      ? 145 +
+                          widget.bottomPadding +
+                          LayoutUtils.getSizes(trailPreviewUIKey).height
                       : 120,
               right: 20,
               child: SizedBox(
@@ -159,7 +161,9 @@ class _MapUIState extends State<MapUI> {
               bottom: (widget.mapMode == MapMode.overview)
                   ? 120 + widget.bottomPadding
                   : (widget.mapMode == MapMode.preview)
-                      ? 145 + LayoutUtils.getSizes(trailPreviewUIKey).height
+                      ? 145 +
+                          widget.bottomPadding +
+                          LayoutUtils.getSizes(trailPreviewUIKey).height
                       : 120,
               left: 20,
               child: const SizedBox(
@@ -170,63 +174,63 @@ class _MapUIState extends State<MapUI> {
           AnimatedPositioned(
               duration: const Duration(milliseconds: 300),
               curve: Curves.easeInOutCubic,
-              bottom: (widget.mapMode == MapMode.create) ? 20 : -200,
+              bottom: (widget.mapMode == MapMode.create)
+                  ? 20 + widget.bottomPadding
+                  : -200,
               left: 20,
-              child: SafeArea(
-                child: SizedBox(
-                  height: 46,
-                  width: MediaQuery.of(context).size.width - 40,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.max,
-                    children: [
-                      Expanded(
-                        child: RoundedButton(
-                          onPress: () {
-                            Navigator.of(context).pushNamed('/create');
-                          },
-                          label: 'Ajouter',
-                          icon: SmartFloreIcons.addMarker,
-                        ),
+              child: SizedBox(
+                height: 46,
+                width: MediaQuery.of(context).size.width - 40,
+                child: Row(
+                  mainAxisSize: MainAxisSize.max,
+                  children: [
+                    Expanded(
+                      child: RoundedButton(
+                        onPress: () {
+                          Navigator.of(context).pushNamed('/create');
+                        },
+                        label: 'Ajouter',
+                        icon: SmartFloreIcons.addMarker,
                       ),
-                      const SizedBox(width: 14),
-                      Container(
-                        width: 46,
-                        height: 46,
-                        decoration: BoxDecoration(
-                          border: Border.all(
-                              color: Theme.of(context).colorScheme.primary,
-                              width: 1),
-                          shape: BoxShape.circle,
-                        ),
-                        child: FloatingActionButton(
-                            backgroundColor: Colors.white,
-                            shape: const CircleBorder(),
-                            child: Container(
-                                width: 14,
-                                height: 14,
-                                decoration: BoxDecoration(
-                                    borderRadius: const BorderRadius.all(
-                                        Radius.circular(2)),
-                                    color:
-                                        Theme.of(context).colorScheme.primary)),
-                            onPressed: () {
-                              BlocProvider.of<CreateBloc>(context)
-                                  .add(const CreateEvent.pause());
-                              showDialog(
-                                  context: context,
-                                  barrierDismissible: false,
-                                  builder: (context) =>
-                                      Modal(CreateEndModal(onClose: () {
-                                        BlocProvider.of<CreateBloc>(context)
-                                            .add(const CreateEvent.unPause());
-                                        Navigator.of(context).pop();
-                                      })),
-                                  barrierColor:
-                                      Colors.black.withValues(alpha: 0.1));
-                            }),
+                    ),
+                    const SizedBox(width: 14),
+                    Container(
+                      width: 46,
+                      height: 46,
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                            color: Theme.of(context).colorScheme.primary,
+                            width: 1),
+                        shape: BoxShape.circle,
                       ),
-                    ],
-                  ),
+                      child: FloatingActionButton(
+                          backgroundColor: Colors.white,
+                          shape: const CircleBorder(),
+                          child: Container(
+                              width: 14,
+                              height: 14,
+                              decoration: BoxDecoration(
+                                  borderRadius: const BorderRadius.all(
+                                      Radius.circular(2)),
+                                  color:
+                                      Theme.of(context).colorScheme.primary)),
+                          onPressed: () {
+                            BlocProvider.of<CreateBloc>(context)
+                                .add(const CreateEvent.pause());
+                            showDialog(
+                                context: context,
+                                barrierDismissible: false,
+                                builder: (context) =>
+                                    Modal(CreateEndModal(onClose: () {
+                                      BlocProvider.of<CreateBloc>(context)
+                                          .add(const CreateEvent.unPause());
+                                      Navigator.of(context).pop();
+                                    })),
+                                barrierColor:
+                                    Colors.black.withValues(alpha: 0.1));
+                          }),
+                    ),
+                  ],
                 ),
               )),
           AnimatedPositioned(
@@ -235,7 +239,9 @@ class _MapUIState extends State<MapUI> {
               onEnd: () {
                 setState(() {});
               },
-              bottom: (widget.mapMode == MapMode.preview) ? 156 - 30 : -200,
+              bottom: (widget.mapMode == MapMode.preview)
+                  ? 156 - 30 + widget.bottomPadding
+                  : -200,
               left: 20,
               child: Center(
                 child: SizedBox(

--- a/lib/components/panel/species_panel.dart
+++ b/lib/components/panel/species_panel.dart
@@ -60,7 +60,7 @@ class _SpeciesPanelWidgetState extends State<SpeciesPanelWidget>
   Widget build(BuildContext context) {
     double screenH = MediaQuery.of(context).size.height;
     double screenW = MediaQuery.of(context).size.width;
-    double bottomPadding = MediaQuery.of(context).padding.bottom / 4;
+    double bottomPadding = MediaQuery.of(context).padding.bottom;
 
     return MultiBlocListener(
       listeners: [

--- a/lib/components/panel/trails_panel.dart
+++ b/lib/components/panel/trails_panel.dart
@@ -70,7 +70,7 @@ class _TrailsPanelWidgetState extends State<TrailsPanelWidget>
     Color primary = Theme.of(context).colorScheme.primary;
     double screenH = MediaQuery.of(context).size.height;
     double screenW = MediaQuery.of(context).size.width;
-    double bottomPadding = MediaQuery.of(context).padding.bottom / 4;
+    double bottomPadding = MediaQuery.of(context).padding.bottom;
 
     return BlocListener<MapBloc, MapState>(
       listener: (context, state) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:smartflore/_env/app_env.dart';
@@ -130,6 +131,8 @@ void main() async {
       getUserInfo: getUserInfo);
 
   Bloc.observer = SimpleBlocObserver();
+
+  SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
   runApp(RootRestorationScope(
     restorationId: 'root',

--- a/lib/screens/create/search_screen.dart
+++ b/lib/screens/create/search_screen.dart
@@ -91,6 +91,7 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
   Widget build(BuildContext context) {
     ThemeData theme = Theme.of(context);
     double screenW = MediaQuery.of(context).size.width;
+    double bottomPadding = MediaQuery.of(context).padding.bottom;
     return BlocListener<CreateBloc, CreateState>(
       listener: (context, state) {
         state.whenOrNull(
@@ -130,8 +131,8 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
             fit: StackFit.expand,
             children: [
               selectedTaxon == null
-                  ? buildSearchUI(theme)
-                  : buildTaxonUI(theme, screenW),
+                  ? buildSearchUI(theme, bottomPadding)
+                  : buildTaxonUI(theme, screenW, bottomPadding),
               widget.simpleSearch
                   ? Container()
                   : Align(
@@ -147,7 +148,8 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
                               borderRadius:
                                   const BorderRadius.all(Radius.circular(6))),
                           child: Padding(
-                            padding: const EdgeInsets.fromLTRB(36, 24, 36, 24),
+                            padding: EdgeInsets.fromLTRB(
+                                36, 24, 36, 24 + bottomPadding),
                             child: SizedBox(
                               height: 46,
                               child: RoundedButton(
@@ -235,7 +237,7 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
             }));
   }
 
-  Widget buildSearchUI(ThemeData theme) {
+  Widget buildSearchUI(ThemeData theme, double bottomPadding) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(36.0, 16, 36, 16),
       child: Column(
@@ -259,8 +261,8 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
           (currentSearch != '')
               ? Expanded(
                   child: Padding(
-                    padding:
-                        EdgeInsets.only(bottom: widget.simpleSearch ? 0 : 90.0),
+                    padding: EdgeInsets.only(
+                        bottom: widget.simpleSearch ? 0 : 90.0 + bottomPadding),
                     child: Container(child: buildHits(context, theme)),
                   ),
                 )
@@ -270,7 +272,7 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
     );
   }
 
-  Widget buildTaxonUI(ThemeData theme, double screenW) {
+  Widget buildTaxonUI(ThemeData theme, double screenW, double bottomPadding) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 36.0),
       child: SingleChildScrollView(
@@ -343,7 +345,9 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
                   return state.maybeWhen(
                       loaded: (taxon) {
                         selectedTaxonSF = taxon;
-                        return Flexible(child: buildGridGallery(theme, taxon));
+                        return Flexible(
+                            child:
+                                buildGridGallery(theme, taxon, bottomPadding));
                       },
                       orElse: () => const Center(
                               child: Padding(
@@ -359,7 +363,7 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
     );
   }
 
-  Widget buildGridGallery(ThemeData theme, Taxon taxon) {
+  Widget buildGridGallery(ThemeData theme, Taxon taxon, double bottomPadding) {
     List<ImageAPI> imageList = [];
     for (var tab in taxon.tabs) {
       if (tab.type == TabTypeEnum.gallery.name) {
@@ -432,7 +436,7 @@ class _SearchTaxonScreenState extends State<SearchTaxonScreen> {
                       })),
             ),
           ),
-          SizedBox(height: widget.simpleSearch ? 0 : 118)
+          SizedBox(height: widget.simpleSearch ? 0 : 118 + bottomPadding)
         ],
       ),
     );


### PR DESCRIPTION
- Use full system bottom padding instead of dividing by 4
- Apply bottom padding to all positioned elements (preview card, buttons, panels)
- Remove redundant SafeArea wrapper in create mode
- Fix search screen bottom button and scrollable content padding

This ensures all interactive elements remain visible above the Android 3-button navigation bar in edge-to-edge mode.